### PR TITLE
NGX-239: Set nginx:nginx ownership for NGINX cache directories

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,14 @@
     state: directory
   with_items: "{{ nginx_config_dirs }}"
 
+- name: Set ownership for NGINX cache directories
+  file:
+    name: /var/nginx/cache
+    owner: nginx
+    group: nginx
+    state: directory
+    recurse: yes
+
 - name: Create pidfile
   file:
     name: "{{ nginx_pid }}"


### PR DESCRIPTION
- Set ownership of /var/nginx/cache to nginx:nginx recursively. Fixes bug when child directory is deleted and NGINX is unable to recreate cache folder.