### PR TITLE
NGX-235: configure proxy_bind directive

### DIFF
--- a/templates/etc/nginx/proxy.conf.j2
+++ b/templates/etc/nginx/proxy.conf.j2
@@ -1,6 +1,7 @@
 # {{ template_destpath }}
 # {{ ansible_managed }}
 
+proxy_bind              {{ ansible_default_ipv4.address }};
 proxy_buffers           {{ nginx_proxy_buffers|join(' ') }};
 proxy_buffer_size       {{ nginx_proxy_buffer_size }};
 proxy_busy_buffers_size {{ nginx_proxy_busy_buffers_size }};


### PR DESCRIPTION
- Makes outgoing connections to a proxied server originate from the specified local IP address.