### PR TITLE
NGX-257: reduce open_file_cache* times drastically

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,11 +42,11 @@ nginx_cache_time_default: 5
 nginx_etag: true
 nginx_ssi: false
 
-nginx_open_file_cache_errors: false
-nginx_open_file_cache_inactive: 8m
+nginx_open_file_cache_errors: true
+nginx_open_file_cache_inactive: 2s
 nginx_open_file_cache_max: 16536
-nginx_open_file_cache_min_uses: 1
-nginx_open_file_cache_valid: "5m"
+nginx_open_file_cache_min_uses: 2
+nginx_open_file_cache_valid: "3s"
 
 #
 # Compression

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,7 @@
     - etc/nginx/nginx.conf
     - etc/nginx/mime.types
     - etc/nginx/proxy.conf
+  notify: restart nginx    
   tags: profile
 
 - name: Include systemd restart configuation


### PR DESCRIPTION
- When deleting cache files from the disk, we want to use low open_file_cache* times to prevent items being served from a deleted cache file.