### PR TITLE
NGX-307: client_max_body_size (and additional) tunables/defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Available variables are listed below with their default values (you can also see
 | nginx_proxy_includes | Default: `/etc/nginx/proxy.conf`
 | nginx_site_includes | Default: `/etc/nginx/conf.d/*.conf`
 
+### Core
+| Variable | Description |
+| -------- | ----------- |
+| nginx_client_body_buffer_size | Default `1m`
+| nginx_client_header_buffer_size | Default `2k`
+| nginx_client_max_body_size | Default `512m`
+
 ### Caching
 | Variable | Description |
 | -------- | ----------- |
@@ -65,12 +72,13 @@ Available variables are listed below with their default values (you can also see
 | -------- | ----------- |
 | nginx_hsts_enable | Default: `false`
 | nginx_http2_enable | Default: `true`
+| nginx_http2_push_preload | Default: `true`
 | nginx_keepalive_requests | Default: `100`
 | nginx_keepalive_timeout | Default: `30`
 | nginx_multi_accept | Default: `true`
 | nginx_reset_timedout_connection | Default: `true`
 | nginx_sendfile | Default: `true`
-| nginx_tcp_nodelay | Default: `true`
+| nginx_tcp_nodelay | Default: `false`
 | nginx_tcp_nopush | Default: `true`
 
 ### Logging
@@ -88,6 +96,7 @@ Available variables are listed below with their default values (you can also see
 | nginx_proxy_busy_buffers_size | Default: `64k`
 | nginx_proxy_cache_key | Default: `"$scheme$request_method$host$request_uri"`
 | nginx_proxy_connect_timeout | Default: `90`
+| nginx_proxy_hide_header | Default: `Upgrade`
 | nginx_proxy_read_timeout | Default: `90`
 | nginx_proxy_redirect | Default: `false`
 | nginx_proxy_send_timeout | Default: `90`
@@ -105,7 +114,7 @@ Available variables are listed below with their default values (you can also see
 | Variable | Description |
 | -------- | ----------- |
 | nginx_ssl_enable | Default: `true`
-| nginx_ssl_ciphers | Default: `["EECDH+AESGCM", "EDH+AESGCM"]`
+| nginx_ssl_ciphers | Default: `["EECDH+AESGCM", "EDH+AESGCM", "AES256+EECDH", "AES256+EDH", "ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-GCM-SHA256"]`
 | nginx_ssl_protocols | Default: `["TLSv1.2", "TLSv1.3"]`
 | nginx_ssl_session_cache | Default: `"shared:SSL:32m"`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,14 @@ nginx_systemd_restart: false
 systemd_restart_setting: on-failure
 
 #
+# Core
+#
+
+nginx_client_body_buffer_size: 1m
+nginx_client_header_buffer_size: 2k
+nginx_client_max_body_size: 512m
+
+#
 # Caching
 #
 
@@ -42,7 +50,7 @@ nginx_cache_time_default: 5
 nginx_etag: true
 nginx_ssi: false
 
-nginx_open_file_cache_errors: true
+nginx_open_file_cache_errors: false
 nginx_open_file_cache_inactive: 2s
 nginx_open_file_cache_max: 16536
 nginx_open_file_cache_min_uses: 2
@@ -62,12 +70,13 @@ nginx_gzip_min_length: 256
 
 nginx_hsts_enable: false
 nginx_http2_enable: true
+nginx_http2_push_preload: false
 nginx_keepalive_requests: 100
 nginx_keepalive_timeout: 30
 nginx_multi_accept: true
 nginx_reset_timedout_connection: true
 nginx_sendfile: true
-nginx_tcp_nodelay: true
+nginx_tcp_nodelay: false
 nginx_tcp_nopush: true
 
 #
@@ -104,6 +113,10 @@ nginx_ssl_enable: true
 nginx_ssl_ciphers:
   - EECDH+AESGCM
   - EDH+AESGCM
+  - AES256+EECDH
+  - AES256+EDH
+  - ECDHE-RSA-AES128-GCM-SHA256
+  - ECDHE-ECDSA-AES128-GCM-SHA256
 
 nginx_ssl_protocols:
   - TLSv1.2

--- a/templates/etc/nginx/nginx.conf.j2
+++ b/templates/etc/nginx/nginx.conf.j2
@@ -23,7 +23,7 @@ include                     {{ nginx_module_includes }};
 
 events {
     worker_connections      {{ nginx_worker_connections }};
-    multi_accept            {{ "on" if nginx_multi_accept else "off" }};
+    multi_accept            {{ "on" if nginx_multi_accept | bool else "off" }};
 }
 
 http {
@@ -42,28 +42,31 @@ http {
     disable_symlinks        if_not_owner;
     keepalive_requests      {{ nginx_keepalive_requests }};
     keepalive_timeout       {{ nginx_keepalive_timeout }};
-    reset_timedout_connection {{ "on" if nginx_reset_timedout_connection else "off" }};
-    sendfile                {{ "on" if nginx_sendfile else "off" }};
+    reset_timedout_connection {{ "on" if nginx_reset_timedout_connection | bool else "off" }};
+    sendfile                {{ "on" if nginx_sendfile | bool else "off" }};
     server_names_hash_bucket_size 128;
-    tcp_nodelay             {{ "on" if nginx_tcp_nodelay else "off" }};
-    tcp_nopush              {{ "on" if nginx_tcp_nopush else "off" }};
+    tcp_nodelay             {{ "on" if nginx_tcp_nodelay | bool else "off" }};
+    tcp_nopush              {{ "on" if nginx_tcp_nopush | bool else "off" }};
+    http2_push_preload      {{ "on" if nginx_http2_push_preload | bool else "off" }};
 
     # Client
-    client_max_body_size    10m;
-    client_body_buffer_size 128k;
+    client_body_buffer_size {{ nginx_client_body_buffer_size }};
+    client_header_buffer_size {{ nginx_client_header_buffer_size }};
+    client_max_body_size    {{ nginx_client_max_body_size }};
 
+    
     # Caching
-    etag                    {{ "on" if nginx_etag else "off" }};
-    ssi                     {{ "on" if nginx_ssi else "off" }};
+    etag                    {{ "on" if nginx_etag | bool else "off" }};
+    ssi                     {{ "on" if nginx_ssi | bool else "off" }};
 
     open_file_cache         max={{ nginx_open_file_cache_max }}
                             inactive={{ nginx_open_file_cache_inactive }};
     open_file_cache_valid   {{ nginx_open_file_cache_valid }};
     open_file_cache_min_uses {{ nginx_open_file_cache_min_uses }};
-    open_file_cache_errors  {{ "on" if nginx_open_file_cache_errors else "off" }};
+    open_file_cache_errors  {{ "on" if nginx_open_file_cache_errors | bool else "off" }};
 
     # Compression
-    gzip                    {{ "on" if nginx_gzip_enabled else "off" }};
+    gzip                    {{ "on" if nginx_gzip_enabled | bool else "off" }};
     gzip_buffers            16 8k;
     gzip_comp_level         {{ nginx_gzip_comp_level }};
     gzip_min_length         {{ nginx_gzip_min_length }};

--- a/templates/etc/nginx/proxy.conf.j2
+++ b/templates/etc/nginx/proxy.conf.j2
@@ -7,7 +7,7 @@ proxy_buffer_size           {{ nginx_proxy_buffer_size }};
 proxy_busy_buffers_size     {{ nginx_proxy_busy_buffers_size }};
 
 proxy_cache                 {{ nginx_cache_name }};
-proxy_cache_convert_head    {{ "on" if nginx_cache_convert_head else "off" }};
+proxy_cache_convert_head    {{ "on" if nginx_cache_convert_head | bool else "off" }};
 proxy_cache_key             {{ nginx_proxy_cache_key }};
 proxy_cache_lock            on;
 proxy_cache_path            /var/nginx/cache/{{ nginx_cache_name }}
@@ -21,18 +21,20 @@ proxy_cache_valid 500       0;
 proxy_store_access          user:rw group:rw all:r;
 
 {% if not (nginx_cache_honor_cc and nginx_cache_honor_expires and nginx_cache_honor_cookies) %}
-proxy_ignore_headers        {{ "" if nginx_cache_honor_cc else "Cache-Control" }} {{ "" if nginx_cache_honor_expires else "Expires" }} {{ "" if nginx_cache_honor_cookies else "Set-Cookie" }};
+proxy_ignore_headers        {{ "" if nginx_cache_honor_cc | bool else "Cache-Control" }} {{ "" if nginx_cache_honor_expires | bool else "Expires" }} {{ "" if nginx_cache_honor_cookies | bool else "Set-Cookie" }};
 {% endif %}
 
 proxy_connect_timeout       {{ nginx_proxy_connect_timeout }};
 proxy_read_timeout          {{ nginx_proxy_read_timeout }};
-proxy_redirect              {{ "on" if nginx_proxy_redirect else "off" }};
+proxy_redirect              {{ "on" if nginx_proxy_redirect | bool else "off" }};
 proxy_send_timeout          {{ nginx_proxy_send_timeout }};
 
 proxy_set_header            Host                $http_host;
 proxy_set_header            X-Real-IP           $remote_addr;
 proxy_set_header            X-Forwarded-For     $proxy_add_x_forwarded_for;
 proxy_set_header            X-Forwarded-Proto   $scheme;
+
+proxy_hide_header           Upgrade;
 
 proxy_ssl_name              $host;
 proxy_ssl_verify            off;


### PR DESCRIPTION
- Increase the default value for client_max_body_size to 512m to avoid potential 413 Request Entity Too Large NGINX errors.
- Add/introduce new NGINX tunables/defaults: client_header_buffer_size (2k), client_body_buffer_size (1m), http2_push_preload (on), proxy_hide_header (Upgrade)
- Turn off tcp_nodelay
- Loosen default SSL Cipher Suite