### PR TITLE
NGX-319: bugfix for nginx_proxy_hide_header as extra argument (-e)

### DIFF
--- a/templates/etc/nginx/proxy.conf.j2
+++ b/templates/etc/nginx/proxy.conf.j2
@@ -34,6 +34,10 @@ proxy_set_header            X-Real-IP           $remote_addr;
 proxy_set_header            X-Forwarded-For     $proxy_add_x_forwarded_for;
 proxy_set_header            X-Forwarded-Proto   $scheme;
 
+{% if nginx_proxy_hide_header is string %}
+{% set nginx_proxy_hide_header = nginx_proxy_hide_header.split(' ') %}
+{% endif %}
+
 {% for header in nginx_proxy_hide_header -%}
 proxy_hide_header           {{ header }};
 {% endfor %}


### PR DESCRIPTION
- If multiple args are passed via command-line using "-e nginx_proxy_hide_header='Upgrade ...'", then we split the string into a list.