### PR TITLE
T3O2-3794: Restoring original visitor IPs for Trusted Proxies (Cloudflare)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Available variables are listed below with their default values (you can also see
 | nginx_module_includes | Default: `/usr/share/nginx/modules/*.conf`
 | nginx_proxy_includes | Default: `/etc/nginx/proxy.conf`
 | nginx_site_includes | Default: `/etc/nginx/conf.d/*.conf`
+| nginx_trusted_proxies_includes | Default: `/etc/nginx/trusted_proxies.conf`
 
 ### Core
 | Variable | Description |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ nginx_pid: /var/run/nginx.pid
 nginx_mime_includes: /etc/nginx/mime.types
 nginx_module_includes: /usr/share/nginx/modules/*.conf
 nginx_proxy_includes: /etc/nginx/proxy.conf
+nginx_trusted_proxies_includes: /etc/nginx/trusted_proxies.conf
 nginx_site_includes: /etc/nginx/conf.d/*.conf
 
 nginx_systemd_restart: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: ansible.posix
+  - name: community.general

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -23,6 +23,7 @@
       - nginx_proxy_includes
       - nginx_site_includes
       - nginx_ssl_session_cache
+      - nginx_trusted_proxies_includes
       - nginx_worker_processes
 
 - name: Check required NGINX variables (strings)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,7 @@
     - etc/nginx/nginx.conf
     - etc/nginx/mime.types
     - etc/nginx/proxy.conf
+    - etc/nginx/trusted_proxies.conf
   notify: Restart nginx
   tags: profile
 

--- a/templates/etc/nginx/nginx.conf.j2
+++ b/templates/etc/nginx/nginx.conf.j2
@@ -38,6 +38,9 @@ http {
     include                 {{ nginx_mime_includes }};
     default_type            application/octet-stream;
 
+    # Trusted Proxies
+    include                 {{ nginx_trusted_proxies_includes }};
+
     # Connection
     disable_symlinks        if_not_owner;
     keepalive_requests      {{ nginx_keepalive_requests }};

--- a/templates/etc/nginx/trusted_proxies.conf.j2
+++ b/templates/etc/nginx/trusted_proxies.conf.j2
@@ -1,0 +1,33 @@
+# {{ template_destpath }}
+# {{ ansible_managed }}
+
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+
+###############################################################################
+# Set Real IP for CloudFlare IPs
+# CloudFlare IP List: https://www.cloudflare.com/ips/
+##
+
+set_real_ip_from 103.21.244.0/22;
+set_real_ip_from 103.22.200.0/22;
+set_real_ip_from 103.31.4.0/22;
+set_real_ip_from 104.16.0.0/13;
+set_real_ip_from 104.24.0.0/14;
+set_real_ip_from 108.162.192.0/18;
+set_real_ip_from 131.0.72.0/22;
+set_real_ip_from 141.101.64.0/18;
+set_real_ip_from 162.158.0.0/15;
+set_real_ip_from 172.64.0.0/13;
+set_real_ip_from 173.245.48.0/20;
+set_real_ip_from 188.114.96.0/20;
+set_real_ip_from 190.93.240.0/20;
+set_real_ip_from 197.234.240.0/22;
+set_real_ip_from 198.41.128.0/17;
+set_real_ip_from 2400:cb00::/32;
+set_real_ip_from 2606:4700::/32;
+set_real_ip_from 2803:f800::/32;
+set_real_ip_from 2405:b500::/32;
+set_real_ip_from 2405:8100::/32;
+set_real_ip_from 2c0f:f248::/32;
+set_real_ip_from 2a06:98c0::/29;


### PR DESCRIPTION
- This allows the visitors original IP to be logged in the NGINX access log.  The file is also set up to handle other CDNs in the future if necessary.