### PR TITLE
NGX-806: Fix Config Dir Permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     state: directory
     owner: root
     group: root
-    mode: "0750"
+    mode: "0755"
   with_items: "{{ nginx_config_dirs }}"
 
 - name: Create NGINX cache directory


### PR DESCRIPTION
The permissions on Nginx config directories was erroneously set to 750.  When owned by root:root, they need to be set to 755, so that nginx processes can read files in /etc/nginx such as an http authorization file.