### PR TITLE
NGX-738: Add caching for 301 redirects in NGINX configuration

### DIFF
--- a/templates/etc/nginx/proxy.conf.j2
+++ b/templates/etc/nginx/proxy.conf.j2
@@ -16,6 +16,7 @@ proxy_cache_path            /var/nginx/cache/{{ nginx_cache_name }}
                             inactive={{ nginx_cache_inactive }};
 proxy_cache_use_stale       updating error timeout http_502 http_503 http_504;
 proxy_cache_valid 200       {{ nginx_cache_time_default }}s;
+proxy_cache_valid 301       {{ nginx_cache_time_default }}s;
 proxy_cache_valid 404       {{ nginx_cache_time_404 }}s;
 proxy_cache_valid 500       0;
 proxy_store_access          user:rw group:rw all:r;


### PR DESCRIPTION
This commit introduces caching for 301 redirect responses in the NGINX configuration. The 'proxy_cache_valid' directive has been updated to cache 301 status codes for a default period specified by the 'nginx_cache_time_default' variable. This change aims to improve performance by reducing the load on the server for frequently accessed redirected URLs and ensures a faster response time for end users. The caching durations for 200 and 404 status codes remain unchanged.

Related to performance optimization efforts.
