### PR TITLE
NGX-868: Remove obsoleted nginx_http2_push_preload directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Available variables are listed below with their default values (you can also see
 | -------- | ----------- |
 | nginx_hsts_enable | Default: `false`
 | nginx_http2_enable | Default: `true`
-| nginx_http2_push_preload | Default: `true`
 | nginx_keepalive_requests | Default: `100`
 | nginx_keepalive_timeout | Default: `30`
 | nginx_multi_accept | Default: `true`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,7 +71,6 @@ nginx_gzip_min_length: 256
 
 nginx_hsts_enable: false
 nginx_http2_enable: true
-nginx_http2_push_preload: false
 nginx_keepalive_requests: 100
 nginx_keepalive_timeout: 30
 nginx_multi_accept: true

--- a/templates/etc/nginx/nginx.conf.j2
+++ b/templates/etc/nginx/nginx.conf.j2
@@ -50,7 +50,6 @@ http {
     server_names_hash_bucket_size 128;
     tcp_nodelay             {{ "on" if nginx_tcp_nodelay | bool else "off" }};
     tcp_nopush              {{ "on" if nginx_tcp_nopush | bool else "off" }};
-    http2_push_preload      {{ "on" if nginx_http2_push_preload | bool else "off" }};
 
     # Client
     client_body_buffer_size {{ nginx_client_body_buffer_size }};


### PR DESCRIPTION
```
Changes with nginx 1.25.1                                        13 Jun 2023

    *) Change: HTTP/2 server push support has been removed.
```