### PR TITLE
NGX-889: Create imh-override.conf systemd file

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,5 @@
 - name: Restart nginx
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: nginx
     state: restarted
+    daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,6 +89,25 @@
   notify: Restart nginx
   tags: profile
 
+- name: Creates service directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/{{ nginx_daemon }}.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Create override.conf with ExecStartPre directive
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/{{ nginx_daemon }}.service.d/imh-override.conf
+    content: |
+      [Service]
+      ExecStartPre=/usr/bin/rm -f /var/run/nginx_status.sock
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart nginx
+
 - name: Include systemd restart configuation
   ansible.builtin.include_tasks: systemd.yml
   when: >-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,7 @@
     dest: /etc/systemd/system/{{ nginx_daemon }}.service.d/imh-override.conf
     content: |
       [Service]
-      ExecStartPre=/usr/bin/rm -f /var/run/nginx_status.sock
+      ExecStartPre=/bin/rm -f /var/run/nginx_status.sock
     owner: root
     group: root
     mode: "0644"

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -25,14 +25,6 @@
     systemd_version: >-
       {{ ansible_facts.packages['systemd'][0].version }}
 
-- name: Creates service directory
-  ansible.builtin.file:
-    path: /etc/systemd/system/{{ nginx_daemon }}.service.d
-    state: directory
-    owner: root
-    group: root
-    mode: "0755"
-
 - name: Create service file
   ansible.builtin.template:
     src: etc/systemd/restart.conf.j2


### PR DESCRIPTION
- Adds an ExecStartPre command to remove stale nginx_status.sock file left by nginx-status-module.  The stale .sock file prevents Nginx from starting.
- Adjust Restart nginx handler to use systemd_service module and reload systemd daemon if the imh-override.conf is created
- Move the creation of the systemd nginx override directory out of systemd.yml to main.yml